### PR TITLE
shared: make it work

### DIFF
--- a/roles/add_certbot/tasks/main.yml
+++ b/roles/add_certbot/tasks/main.yml
@@ -34,6 +34,7 @@
   command: a2enmod ssl
   notify: reload apache
 
+# todo move out
 - name: Enable SSL site
   command: a2ensite {{ config_file }}
   notify: reload apache

--- a/roles/properties/shared/tasks/main.yml
+++ b/roles/properties/shared/tasks/main.yml
@@ -8,10 +8,6 @@
     state: present
     update_cache: yes
 
-- name: Enable SSL module in Apache
-  command: a2enmod ssl
-  notify: reload apache
-
 - name: Create the self-signed SSL Certificate
   include_role:
     name: add_self-signed_certs
@@ -29,8 +25,8 @@
     line: 'LoadModule expires_module /usr/lib/apache2/modules/mod_expires.so'
     state: present
 
-- name: Enable Apache PHP and headers modules
-  command: a2enmod php8.2 headers
+- name: Enable Apache, SSL and headers modules
+  command: a2enmod php8.2 ssl headers
   notify: reload apache
 
 - name: Enable SSL site


### PR DESCRIPTION
without css
http://shared.php.backend.lol/

css is not loaded bevćause it is looking for it in a `shared` folder, inside the repo.
This all was added later and Ninette was working on this in parallel. My guess is, that this will be fixed after running the rsync again,