### PR TITLE
fix: update the restore name to use backup tar file name

### DIFF
--- a/roles/properties/main/tasks/restore.yml
+++ b/roles/properties/main/tasks/restore.yml
@@ -1,27 +1,35 @@
 # Restore backup in local restore directory
 - name: Create a local restore directory with today's date
   file:
-    path: "{{ restore_dir }}/{{ backup_name }}"
+    path: "{{ restore_dir }}"
     state: directory
     mode: "755"
 
 - name: Restore backup with Restic
-  command: restic -r s3:{{ DO_bucket_url }}/{{ DO_bucket_name }}/main restore latest --target {{ restore_dir }}/{{ backup_name }}
+  command: restic -r s3:{{ DO_bucket_url }}/{{ DO_bucket_name }}/main restore latest --target {{ restore_dir }}/
   environment:
     AWS_ACCESS_KEY_ID: "{{ DO_access_key }}"
     AWS_SECRET_ACCESS_KEY: "{{ DO_secret_key }}"
     RESTIC_PASSWORD: "{{ restic_password }}"
 
-- name: Extract the .tar backup file
+- name: Find all .tar.bz2 files in the source directory
+  find:
+    paths: "{{ restore_dir }}"
+    patterns: "*.tar.bz2"
+  register: tar_files
+
+- name: Extract each .tar.bz2 file
   unarchive:
-    src: "{{ restore_dir }}/{{ backup_name }}/{{ backup_name }}.tar.bz2"
+    src: "{{ item }}"
     dest: "{{ restore_dir }}"
     remote_src: yes
+  loop: "{{ tar_files.files | map(attribute='path') | list }}"
 
 - name: Restore MySQL database from the dump
-  command: "mysql -u nobody {{ db_name }} < {{ restore_dir }}/{{ backup_name }}/{{ db_name }}.sql"
+  shell: "mysql -u nobody {{ db_name }} < {{ item | regex_replace('(.tar.bz2)$', '')}}/{{ db_name }}.sql"
+  loop: "{{ tar_files.files | map(attribute='path') | list }}"
 
 - name: Remove temporary restore directory
   file:
-    path: "{{ restore_dir }}/{{ backup_name }}"
+    path: "{{ restore_dir }}"
     state: absent

--- a/roles/restore_property/tasks/main.yml
+++ b/roles/restore_property/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Create temporary local restore directory if it doesn't exist
   file:
-    path: "{{ restore_dir }}/{{ restore_name }}"
+    path: "{{ restore_dir }}"
     state: directory
     mode: "755"
 
@@ -23,18 +23,25 @@
     AWS_SECRET_ACCESS_KEY: "{{ DO_secret_key }}"
     RESTIC_PASSWORD: "{{ restic_password }}"
 
-- name: Extract the .tar backup file
+- name: Find all .tar.bz2 files in the source directory
+  find:
+    paths: "{{ restore_dir }}"
+    patterns: "*.tar.bz2"
+  register: tar_files
+
+- name: Extract each .tar.bz2 file
   unarchive:
-    src: "{{ restore_dir }}/local/backups/{{ restore_name }}.tar.bz2"
-    dest: "{{ restore_dir }}/{{ restore_name }}"
+    src: "{{ item }}"
+    dest: "{{ restore_dir }}"
     remote_src: yes
+  loop: "{{ tar_files.files | map(attribute='path') | list }}"
 
 - name: Copy restored data to the doc root
   copy:
-    src: "{{ restore_dir }}/{{ restore_name }}"
+    src: "{{ restore_dir }}"
     dest: "{{ backup_path }}"
 
 - name: Remove temporary restore directory
   file:
-    path: "{{ restore_dir }}/{{ restore_name }}"
+    path: "{{ restore_dir }}"
     state: absent

--- a/roles/restore_property/vars/main.yml
+++ b/roles/restore_property/vars/main.yml
@@ -1,3 +1,2 @@
 
-restore_name: "{{ property }}-{{ ansible_date_time.date }}"
 restore_dir: /local/restore


### PR DESCRIPTION
fix: update the restore name to use backup tar file name 
 - for example instead of using `property-name-timestamp` use the file name of the backup since the backup date and restore date may not be the same